### PR TITLE
Update logging to use Go-ns and add unit tests

### DIFF
--- a/auth/client.go
+++ b/auth/client.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"net/http"
 
+	"github.com/ONSdigital/go-ns/log"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -15,12 +16,12 @@ func Client(scope string, create func(*http.Client) (interface{}, error)) interf
 
 	ts, err := google.DefaultTokenSource(ctx, scope)
 	if err != nil {
-		panic(err)
+		log.ErrorC("authentication", err, nil)
 	}
 	client := oauth2.NewClient(ctx, ts)
 	c, err := create(client)
 	if err != nil {
-		panic(err)
+		log.ErrorC("authentication", err, nil)
 	}
 	return c
 }

--- a/calendar/calendar_test.go
+++ b/calendar/calendar_test.go
@@ -1,0 +1,124 @@
+package calendar
+
+import (
+	"bytes"
+	"io"
+	//"log"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	gcal "google.golang.org/api/calendar/v3"
+)
+
+func TestCalendar(t *testing.T) {
+	Convey("Given a time", t, func() {
+		now := time.Now()
+
+		Convey("When setMidnight is called", func() {
+			s := setMidnight(now)
+
+			Convey("The time should be set to midnight on today's date", func() {
+				So(s, ShouldContainSubstring, "T00:00:00Z")
+			})
+		})
+	})
+
+	Convey("Given that limitDates is called", t, func() {
+		start, end := limitDates()
+
+		Convey("When comparing the dates", func() {
+			s, err := time.Parse(time.RFC3339, start)
+			if err != nil {
+				panic(err)
+			}
+			e, err := time.Parse(time.RFC3339, end)
+			if err != nil {
+				panic(err)
+			}
+			diff := e.Sub(s)
+
+			Convey("The dates should be 24 hours apart", func() {
+				So(diff, ShouldEqual, time.Duration(24*time.Hour))
+			})
+		})
+	})
+
+	Convey("Given a Calendar with a list of 2 google events", t, func() {
+		c := &Calendar{}
+		eventNum := 2
+		c.Events = createEvents(eventNum)
+		Convey("When Output is called", func() {
+			output := captureOutput(c.Output)
+			Convey("The log should be using the structured format", func() {
+				So(output, ShouldContainSubstring, "\"namespace\"")
+			})
+			Convey("The log should contain 2 lines", func() {
+				count := strings.Count(output, "\"namespace\"")
+				So(count, ShouldEqual, eventNum)
+			})
+		})
+	})
+}
+
+func createEvents(num int) []*gcal.Event {
+	list := []*gcal.Event{}
+	date := "2016-10-24"
+	for x := 0; x < num; x++ {
+
+		creator := &gcal.EventCreator{
+			DisplayName: "bob" + strconv.Itoa(x),
+			Email:       "bob" + strconv.Itoa(x) + "@google.com",
+		}
+		start := &gcal.EventDateTime{
+			Date:     date,
+			DateTime: "",
+		}
+
+		end := &gcal.EventDateTime{
+			Date:     date,
+			DateTime: "",
+		}
+
+		item := &gcal.Event{
+			ColorId:     "color" + strconv.Itoa(x),
+			Creator:     creator,
+			Description: "this is a test event" + strconv.Itoa(x),
+			End:         end,
+			Id:          "testevent" + strconv.Itoa(x),
+			Kind:        "kind" + strconv.Itoa(x),
+			Status:      "good" + strconv.Itoa(x),
+			Start:       start,
+			Summary:     "Event Test Appointment" + strconv.Itoa(x),
+		}
+
+		list = append(list, item)
+	}
+	return list
+}
+
+func captureOutput(f func()) string {
+	stdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() {
+		os.Stdout = stdout
+	}()
+
+	outC := make(chan string)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	f()
+
+	w.Close()
+	out := <-outC
+	return out
+}

--- a/calendar/calendar_test.go
+++ b/calendar/calendar_test.go
@@ -3,7 +3,6 @@ package calendar
 import (
 	"bytes"
 	"io"
-	//"log"
 	"os"
 	"strconv"
 	"strings"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestCalendar(t *testing.T) {
-	Convey("Given a time", t, func() {
+	Convey("Given the current time", t, func() {
 		now := time.Now()
 
 		Convey("When setMidnight is called", func() {
@@ -50,9 +49,11 @@ func TestCalendar(t *testing.T) {
 	Convey("Given a Calendar with a list of 2 google events", t, func() {
 		c := &Calendar{}
 		eventNum := 2
-		c.Events = createEvents(eventNum)
+		c.Events = createEvents(eventNum, true)
+
 		Convey("When Output is called", func() {
 			output := captureOutput(c.Output)
+
 			Convey("The log should be using the structured format", func() {
 				So(output, ShouldContainSubstring, "\"namespace\"")
 			})
@@ -64,7 +65,7 @@ func TestCalendar(t *testing.T) {
 	})
 }
 
-func createEvents(num int) []*gcal.Event {
+func createEvents(num int, withDates bool) []*gcal.Event {
 	list := []*gcal.Event{}
 	date := "2016-10-24"
 	for x := 0; x < num; x++ {
@@ -73,26 +74,29 @@ func createEvents(num int) []*gcal.Event {
 			DisplayName: "bob" + strconv.Itoa(x),
 			Email:       "bob" + strconv.Itoa(x) + "@google.com",
 		}
-		start := &gcal.EventDateTime{
-			Date:     date,
-			DateTime: "",
-		}
-
-		end := &gcal.EventDateTime{
-			Date:     date,
-			DateTime: "",
-		}
 
 		item := &gcal.Event{
 			ColorId:     "color" + strconv.Itoa(x),
 			Creator:     creator,
 			Description: "this is a test event" + strconv.Itoa(x),
-			End:         end,
 			Id:          "testevent" + strconv.Itoa(x),
 			Kind:        "kind" + strconv.Itoa(x),
 			Status:      "good" + strconv.Itoa(x),
-			Start:       start,
 			Summary:     "Event Test Appointment" + strconv.Itoa(x),
+		}
+
+		if withDates {
+			start := &gcal.EventDateTime{
+				Date:     date,
+				DateTime: "",
+			}
+
+			end := &gcal.EventDateTime{
+				Date:     date,
+				DateTime: "",
+			}
+			item.End = end
+			item.Start = start
 		}
 
 		list = append(list, item)

--- a/calendar/event_test.go
+++ b/calendar/event_test.go
@@ -9,20 +9,8 @@ import (
 
 func TestEvent(t *testing.T) {
 	Convey("Given a google calendar event", t, func() {
-		creator := &gcal.EventCreator{
-			DisplayName: "bob",
-			Email:       "bob@google.com",
-		}
-
-		ge := &gcal.Event{
-			ColorId:     "color",
-			Creator:     creator,
-			Description: "this is a test event",
-			Id:          "testevent1",
-			Kind:        "kind",
-			Status:      "good",
-			Summary:     "Event Test Appointment",
-		}
+		events := createEvents(1, false)
+		ge := events[0]
 
 		Convey("When it's an all day event", func() {
 			date := "2016-10-24"

--- a/calendar/event_test.go
+++ b/calendar/event_test.go
@@ -1,0 +1,60 @@
+package calendar
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	gcal "google.golang.org/api/calendar/v3"
+)
+
+func TestEvent(t *testing.T) {
+	Convey("Given a google calendar event", t, func() {
+		creator := &gcal.EventCreator{
+			DisplayName: "bob",
+			Email:       "bob@google.com",
+		}
+
+		ge := &gcal.Event{
+			ColorId:     "color",
+			Creator:     creator,
+			Description: "this is a test event",
+			Id:          "testevent1",
+			Kind:        "kind",
+			Status:      "good",
+			Summary:     "Event Test Appointment",
+		}
+
+		Convey("When it's an all day event", func() {
+			date := "2016-10-24"
+			ge.Start = &gcal.EventDateTime{
+				Date:     date,
+				DateTime: "",
+			}
+
+			ge.End = &gcal.EventDateTime{
+				Date:     date,
+				DateTime: "",
+			}
+			Convey("The converted Start and End fields should contain only a date", func() {
+				event := convert(ge)
+				So(event.Start, ShouldEqual, date)
+			})
+		})
+
+		Convey("When it's an event with a start and end time", func() {
+			date := "2016-10-24"
+			ge.Start = &gcal.EventDateTime{
+				DateTime: date + "T10:45:00-07:00",
+			}
+
+			ge.End = &gcal.EventDateTime{
+				DateTime: date + "T11:00:00-07:00",
+			}
+			Convey("The converted Start and End fields should contain a timestamp", func() {
+				event := convert(ge)
+				So(event.Start, ShouldContainSubstring, "T10:45")
+				So(event.End, ShouldContainSubstring, "T11:00")
+			})
+		})
+	})
+}

--- a/calendar/service.go
+++ b/calendar/service.go
@@ -1,9 +1,9 @@
 package calendar
 
 import (
-	"log"
 	"net/http"
 
+	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-splunk/auth"
 	gcal "google.golang.org/api/calendar/v3"
 )
@@ -30,12 +30,14 @@ func New() *Calendar {
 func (c *Calendar) loadEvents(id string, earliest string, latest string) bool {
 	events, err := c.queryEvents(id, earliest, latest)
 	if err != nil {
-		log.Printf("Unable to retrieve todays events. %v", err.Error())
+		data := make(map[string]interface{})
+		data["args"] = []string{id, earliest, latest}
+		log.ErrorC("Unable to retrieve todays events.", err, data)
 		return false
 	}
 
 	if len(events.Items) == 0 {
-		log.Println("There are no events today.")
+		log.Debug("There are no events today.", nil)
 		return false
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"time"
 
+	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-splunk/analytics"
 	"github.com/ONSdigital/go-splunk/calendar"
 )
 
 func main() {
+	log.Namespace = "go-splunk"
 	calPer := 10 //will be configurable
 	cal := calendar.New()
 	_ = analytics.New()


### PR DESCRIPTION
In order to standardise logging across services, it's preferable to use the log package provided by https://github.com/ONSdigital/go-ns

This provides some standard fields like namespace across all log lines.

Unit tests have been added for internal methods. 
